### PR TITLE
Add basic server with authentication

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules
+uploads
+data.db

--- a/README.md
+++ b/README.md
@@ -1,5 +1,18 @@
 # Vidfolio
 
-This project is a prototype for managing videos with code bookmarks.
-Open `index.html` in a browser to test the interface. Use the **Add Video**
-button to select a video file from your computer.
+This project now includes a simple Node.js server so videos and bookmarks can
+be stored and viewed on the web. Run the server and open `http://localhost:3000`
+in your browser.
+
+## Usage
+
+Install dependencies and start the server:
+
+```bash
+npm install
+npm start
+```
+
+Set the environment variable `ADMIN_PASSWORD` to control the admin login. Only
+logged in administrators can upload videos or add bookmarks. Visitors can watch
+videos and browse existing bookmarks but cannot modify them.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "vidfolio",
+  "version": "1.0.0",
+  "main": "server.js",
+  "scripts": {
+    "start": "node server.js"
+  },
+  "dependencies": {
+    "express": "^4.18.2",
+    "express-session": "^1.17.3",
+    "multer": "^1.4.5-lts.1",
+    "sqlite3": "^5.1.6"
+  }
+}

--- a/public/index.html
+++ b/public/index.html
@@ -102,12 +102,21 @@
             padding: 4px 8px;
             font-size: 12px;
         }
+
+        #auth {
+            margin-bottom: 10px;
+        }
     </style>
     <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
 </head>
 <body>
     <div id="container" class="layout">
         <div id="sidebar">
+            <div id="auth">
+                <input type="password" id="passwordInput" placeholder="Admin password" />
+                <button id="loginBtn">Login</button>
+                <button id="logoutBtn" style="display:none">Logout</button>
+            </div>
             <button id="addVideoBtn">Add Video</button>
             <input id="videoFileInput" type="file" accept="video/*" style="display:none" />
             <div id="videoList"></div>
@@ -137,22 +146,54 @@
         const bookmarkTitle = document.getElementById('bookmarkTitle');
         const bookmarkContent = document.getElementById('bookmarkContent');
         const codeContainer = document.getElementById('codeContainer');
+        const passwordInput = document.getElementById('passwordInput');
+        const loginBtn = document.getElementById('loginBtn');
+        const logoutBtn = document.getElementById('logoutBtn');
+
+        let isAdmin = false;
 
         let videos = [];
         let currentVideoIndex = null;
+
+        function updateVisibility() {
+            if (isAdmin) {
+                addVideoBtn.style.display = 'block';
+                bookmarkForm.style.display = 'block';
+                logoutBtn.style.display = 'inline-block';
+                loginBtn.style.display = 'none';
+                passwordInput.style.display = 'none';
+            } else {
+                addVideoBtn.style.display = 'none';
+                bookmarkForm.style.display = 'none';
+                logoutBtn.style.display = 'none';
+                loginBtn.style.display = 'inline-block';
+                passwordInput.style.display = 'inline-block';
+            }
+        }
+
+        function checkAuth() {
+            fetch('/me').then(r => r.json()).then(d => {
+                isAdmin = d.admin;
+                updateVisibility();
+                loadVideos();
+            });
+        }
+
+        function loadVideos() {
+            fetch('/api/videos').then(r => r.json()).then(v => {
+                videos = v.map(x => ({ ...x, url: '/video/' + x.filename, bookmarks: [] }));
+                renderVideoList();
+            });
+        }
 
         function renderVideoList() {
             videoListDiv.innerHTML = '';
             videos.forEach((v, i) => {
                 const div = document.createElement('div');
                 div.className = 'video-item';
-                const input = document.createElement('input');
-                input.type = 'text';
-                input.value = v.title;
-                input.addEventListener('input', (e) => {
-                    v.title = e.target.value;
-                });
-                div.appendChild(input);
+                const span = document.createElement('span');
+                span.textContent = v.title;
+                div.appendChild(span);
                 div.addEventListener('click', () => loadVideo(i));
                 videoListDiv.appendChild(div);
             });
@@ -168,21 +209,21 @@
                 const timeStr = new Date(b.time * 1000).toISOString().substr(14,5);
                 const span = document.createElement('span');
                 span.textContent = `${timeStr} - ${b.title}`;
-                span.addEventListener('dblclick', () => {
-                    const newTitle = prompt('Edit bookmark title', b.title);
-                    if (newTitle !== null) { b.title = newTitle; renderBookmarkList(); }
-                });
                 span.addEventListener('click', () => {
                     videoPlayer.currentTime = b.time;
                 });
-                const del = document.createElement('button');
-                del.textContent = 'X';
-                del.addEventListener('click', () => {
-                    video.bookmarks.splice(idx,1);
-                    renderBookmarkList();
-                });
                 li.appendChild(span);
-                li.appendChild(del);
+                if (isAdmin) {
+                    const del = document.createElement('button');
+                    del.textContent = 'X';
+                    del.addEventListener('click', () => {
+                        fetch(`/api/bookmarks/${b.id}`, { method: 'DELETE' }).then(() => {
+                            video.bookmarks.splice(idx, 1);
+                            renderBookmarkList();
+                        });
+                    });
+                    li.appendChild(del);
+                }
                 bookmarkList.appendChild(li);
             });
         }
@@ -190,15 +231,15 @@
         function loadVideo(index) {
             currentVideoIndex = index;
             const video = videos[index];
-            if (video.url) {
-                videoPlayer.src = video.url;
-            } else if (video.file) {
-                videoPlayer.src = URL.createObjectURL(video.file);
-            }
-            renderBookmarkList();
+            videoPlayer.src = video.url;
+            fetch(`/api/videos/${video.id}/bookmarks`).then(r => r.json()).then(b => {
+                video.bookmarks = b;
+                renderBookmarkList();
+            });
         }
 
         addVideoBtn.addEventListener('click', () => {
+            if (!isAdmin) return;
             videoFileInput.value = '';
             videoFileInput.click();
         });
@@ -206,24 +247,34 @@
         videoFileInput.addEventListener('change', (e) => {
             const file = e.target.files[0];
             if (file) {
-                videos.push({ title: file.name, file, bookmarks: [] });
-                renderVideoList();
+                const fd = new FormData();
+                fd.append('video', file);
+                fd.append('title', file.name);
+                fetch('/api/videos', { method: 'POST', body: fd })
+                    .then(r => r.json())
+                    .then(v => {
+                        videos.push({ ...v, url: '/video/' + v.filename, bookmarks: [] });
+                        renderVideoList();
+                    });
             }
         });
 
         bookmarkForm.addEventListener('submit', (e) => {
             e.preventDefault();
+            if (!isAdmin) return;
             const video = videos[currentVideoIndex];
             if (!video) return;
             const time = videoPlayer.currentTime;
-            video.bookmarks.push({
-                time,
-                title: bookmarkTitle.value,
-                content: bookmarkContent.value
+            fetch(`/api/videos/${video.id}/bookmarks`, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ time, title: bookmarkTitle.value, content: bookmarkContent.value })
+            }).then(r => r.json()).then(b => {
+                video.bookmarks.push(b);
+                bookmarkTitle.value = '';
+                bookmarkContent.value = '';
+                renderBookmarkList();
             });
-            bookmarkTitle.value = '';
-            bookmarkContent.value = '';
-            renderBookmarkList();
         });
 
         videoPlayer.addEventListener('timeupdate', () => {
@@ -241,6 +292,27 @@
                 codeContainer.innerHTML = marked.parse(current.content || '');
             }
         });
+
+        loginBtn.addEventListener('click', () => {
+            fetch('/login', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+                body: 'password=' + encodeURIComponent(passwordInput.value)
+            }).then(r => {
+                if (r.ok) {
+                    passwordInput.value = '';
+                    checkAuth();
+                } else {
+                    alert('Login failed');
+                }
+            });
+        });
+
+        logoutBtn.addEventListener('click', () => {
+            fetch('/logout', { method: 'POST' }).then(() => checkAuth());
+        });
+
+        checkAuth();
     </script>
 </body>
 </html>

--- a/server.js
+++ b/server.js
@@ -1,0 +1,115 @@
+const express = require('express');
+const session = require('express-session');
+const sqlite3 = require('sqlite3').verbose();
+const multer = require('multer');
+const path = require('path');
+
+const app = express();
+const db = new sqlite3.Database('data.db');
+const upload = multer({ dest: path.join(__dirname, 'uploads') });
+const ADMIN_PASSWORD = process.env.ADMIN_PASSWORD || 'password';
+
+app.use(express.json());
+app.use(express.urlencoded({ extended: true }));
+app.use(session({
+  secret: process.env.SESSION_SECRET || 'secret',
+  resave: false,
+  saveUninitialized: false
+}));
+
+// initialize tables
+db.serialize(() => {
+  db.run(`CREATE TABLE IF NOT EXISTS videos(
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    title TEXT,
+    filename TEXT
+  )`);
+  db.run(`CREATE TABLE IF NOT EXISTS bookmarks(
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    video_id INTEGER,
+    time REAL,
+    title TEXT,
+    content TEXT,
+    FOREIGN KEY(video_id) REFERENCES videos(id)
+  )`);
+});
+
+app.use(express.static('public'));
+
+app.post('/login', (req, res) => {
+  if (req.body.password === ADMIN_PASSWORD) {
+    req.session.admin = true;
+    res.json({ ok: true });
+  } else {
+    res.status(401).json({ error: 'Invalid password' });
+  }
+});
+
+app.post('/logout', (req, res) => {
+  req.session.destroy(() => res.json({ ok: true }));
+});
+
+app.get('/me', (req, res) => {
+  res.json({ admin: !!req.session.admin });
+});
+
+const requireAdmin = (req, res, next) => {
+  if (req.session.admin) return next();
+  res.status(403).json({ error: 'Forbidden' });
+};
+
+app.get('/api/videos', (req, res) => {
+  db.all('SELECT id,title,filename FROM videos', [], (err, rows) => {
+    if (err) return res.status(500).json({ error: err.message });
+    res.json(rows);
+  });
+});
+
+app.post('/api/videos', requireAdmin, upload.single('video'), (req, res) => {
+  const title = req.body.title || req.file.originalname;
+  const filename = req.file.filename;
+  db.run('INSERT INTO videos(title,filename) VALUES(?,?)', [title, filename], function (err) {
+    if (err) return res.status(500).json({ error: err.message });
+    res.json({ id: this.lastID, title, filename });
+  });
+});
+
+app.get('/video/:filename', (req, res) => {
+  const filepath = path.join(__dirname, 'uploads', req.params.filename);
+  res.sendFile(filepath);
+});
+
+app.get('/api/videos/:id/bookmarks', (req, res) => {
+  db.all('SELECT * FROM bookmarks WHERE video_id=? ORDER BY time', [req.params.id], (err, rows) => {
+    if (err) return res.status(500).json({ error: err.message });
+    res.json(rows);
+  });
+});
+
+app.post('/api/videos/:id/bookmarks', requireAdmin, (req, res) => {
+  const { time, title, content } = req.body;
+  db.run('INSERT INTO bookmarks(video_id,time,title,content) VALUES (?,?,?,?)',
+    [req.params.id, time, title, content], function (err) {
+      if (err) return res.status(500).json({ error: err.message });
+      res.json({ id: this.lastID, time, title, content });
+    });
+});
+
+app.put('/api/bookmarks/:id', requireAdmin, (req, res) => {
+  const { title, content } = req.body;
+  db.run('UPDATE bookmarks SET title=?, content=? WHERE id=?',
+    [title, content, req.params.id], function (err) {
+      if (err) return res.status(500).json({ error: err.message });
+      res.json({ ok: true });
+    });
+});
+
+app.delete('/api/bookmarks/:id', requireAdmin, (req, res) => {
+  db.run('DELETE FROM bookmarks WHERE id=?', [req.params.id], function (err) {
+    if (err) return res.status(500).json({ error: err.message });
+    res.json({ ok: true });
+  });
+});
+
+const PORT = process.env.PORT || 3000;
+app.listen(PORT, () => console.log(`Server running on port ${PORT}`));


### PR DESCRIPTION
## Summary
- introduce Node.js server with SQLite storage and admin login
- reorganize static assets under `public/`
- enable video and bookmark CRUD over HTTP
- provide login/logout controls in the UI
- document how to run the new server

## Testing
- `npm install` *(fails: 403 Forbidden - registry access blocked)*
- `npm start` *(fails: cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_685c52d221648323a4772efdd87d33a7