### PR TITLE
Handle missing dotenv gracefully

### DIFF
--- a/server.js
+++ b/server.js
@@ -1,5 +1,13 @@
 
-require('dotenv').config();
+try {
+  if (require('fs').existsSync('.env')) {
+    require('dotenv').config();
+  } else {
+    console.warn('.env file not found, skipping environment variable loading');
+  }
+} catch (err) {
+  console.warn('dotenv module not found, skipping environment variable loading');
+}
 
 const express = require('express');
 const session = require('express-session');
@@ -29,7 +37,7 @@ db.serialize(() => {
   )`);
   db.run(`CREATE TABLE IF NOT EXISTS bookmarks(
     id INTEGER PRIMARY KEY AUTOINCREMENT,
-    video_id INTEGER,ADMIN_PASSWORD
+    video_id INTEGER,
     time REAL,
     title TEXT,
     content TEXT,


### PR DESCRIPTION
## Summary
- add try-catch around dotenv so the server starts even when `.env` or the module is missing

## Testing
- `node server.js` *(fails: cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_685e3990ed7083239a2c1f298c553137