### PR TITLE
Add video category grouping

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -132,6 +132,14 @@
             background: #2b2b2b;
         }
 
+        .category-item {
+            margin-bottom: 6px;
+            cursor: pointer;
+            display: flex;
+            align-items: center;
+            gap: 4px;
+        }
+
         .video-item:hover {
             background: #333;
         }
@@ -232,6 +240,7 @@
                     <button id="logoutBtn" style="display:none">Logout</button>
                 </div>
                 <button id="addVideoBtn">Add Video</button>
+                <button id="addCategoryBtn">Add Category</button>
                 <input id="videoFileInput" type="file" accept="video/*" style="display:none" />
             </div>
             <hr class="divider" />
@@ -269,6 +278,7 @@
     </div>
     <script>
         const addVideoBtn = document.getElementById('addVideoBtn');
+        const addCategoryBtn = document.getElementById('addCategoryBtn');
         const videoFileInput = document.getElementById('videoFileInput');
         const videoListDiv = document.getElementById('videoList');
         const bookmarkList = document.getElementById('bookmarkList');
@@ -309,17 +319,20 @@
         let isAdmin = false;
 
         let videos = [];
+        let categories = [];
         let currentVideoIndex = null;
 
         function updateVisibility() {
             if (isAdmin) {
                 addVideoBtn.style.display = 'block';
+                addCategoryBtn.style.display = 'block';
                 bookmarkForm.style.display = 'block';
                 logoutBtn.style.display = 'inline-block';
                 loginBtn.style.display = 'none';
                 passwordInput.style.display = 'none';
             } else {
                 addVideoBtn.style.display = 'none';
+                addCategoryBtn.style.display = 'none';
                 bookmarkForm.style.display = 'none';
                 logoutBtn.style.display = 'none';
                 loginBtn.style.display = 'inline-block';
@@ -332,6 +345,7 @@
                 isAdmin = d.admin;
                 updateVisibility();
                 loadVideos();
+                loadCategories();
             });
         }
 
@@ -342,63 +356,164 @@
             });
         }
 
+        function loadCategories() {
+            fetch('/api/categories').then(r => r.json()).then(c => {
+                categories = c.map(x => ({ ...x, collapsed: false }));
+                renderVideoList();
+            });
+        }
+
         function renderVideoList() {
             videoListDiv.innerHTML = '';
-            videos.forEach((v, i) => {
-                const div = document.createElement('div');
-                div.className = 'video-item';
-                const span = document.createElement('span');
-                span.textContent = v.title;
-                span.className = 'title-truncate';
-                div.appendChild(span);
-                if (isAdmin) {
-                    const edit = document.createElement('button');
-                    edit.textContent = '✎';
-                    edit.style.marginLeft = '5px';
-                    edit.addEventListener('click', (e) => {
-                        e.stopPropagation();
-                        const title = prompt('New title', v.title);
-                        if (title && title !== v.title) {
-                            fetch(`/api/videos/${v.id}`, {
-                                method: 'PUT',
-                                headers: { 'Content-Type': 'application/json' },
-                                body: JSON.stringify({ title })
-                            }).then(r => {
+
+            function build(parentId, container) {
+                const subCats = categories.filter(c => c.parent_id === parentId);
+                const vids = videos.filter(v => v.category_id === parentId);
+
+                subCats.forEach(cat => {
+                    const wrap = document.createElement('div');
+                    const header = document.createElement('div');
+                    header.className = 'category-item';
+                    const toggle = document.createElement('span');
+                    toggle.textContent = cat.collapsed ? '▶' : '▼';
+                    toggle.style.cursor = 'pointer';
+                    toggle.addEventListener('click', () => { cat.collapsed = !cat.collapsed; renderVideoList(); });
+                    header.appendChild(toggle);
+
+                    const nameSpan = document.createElement('span');
+                    nameSpan.textContent = cat.name;
+                    nameSpan.className = 'title-truncate';
+                    nameSpan.style.marginLeft = '4px';
+                    header.appendChild(nameSpan);
+
+                    if (isAdmin) {
+                        const edit = document.createElement('button');
+                        edit.textContent = '✎';
+                        edit.style.marginLeft = '5px';
+                        edit.addEventListener('click', e => {
+                            e.stopPropagation();
+                            const newName = prompt('New name', cat.name);
+                            if (newName && newName !== cat.name) {
+                                fetch(`/api/categories/${cat.id}`, {
+                                    method: 'PUT',
+                                    headers: { 'Content-Type': 'application/json' },
+                                    body: JSON.stringify({ name: newName })
+                                }).then(r => { if (r.ok) { cat.name = newName; renderVideoList(); } });
+                            }
+                        });
+                        header.appendChild(edit);
+
+                        const del = document.createElement('button');
+                        del.textContent = '🗑';
+                        del.style.marginLeft = '5px';
+                        del.addEventListener('click', e => {
+                            e.stopPropagation();
+                            if (!confirm('Delete this category?')) return;
+                            fetch(`/api/categories/${cat.id}`, { method: 'DELETE' }).then(r => {
                                 if (r.ok) {
-                                    v.title = title;
+                                    categories = categories.filter(c => c.id !== cat.id);
+                                    vids.forEach(v => { if (v.category_id === cat.id) v.category_id = null; });
                                     renderVideoList();
                                 }
                             });
+                        });
+                        header.appendChild(del);
+                    }
+
+                    header.addEventListener('dragover', e => e.preventDefault());
+                    header.addEventListener('drop', e => {
+                        const vid = e.dataTransfer.getData('video');
+                        if (vid) {
+                            const vobj = videos.find(x => x.id == vid);
+                            if (!vobj) return;
+                            fetch(`/api/videos/${vid}`, {
+                                method: 'PUT',
+                                headers: { 'Content-Type': 'application/json' },
+                                body: JSON.stringify({ category_id: cat.id })
+                            }).then(r => { if (r.ok) { vobj.category_id = cat.id; renderVideoList(); } });
                         }
                     });
-                    div.appendChild(edit);
 
-                    const del = document.createElement('button');
-                    del.textContent = '🗑';
-                    del.style.marginLeft = '5px';
-                    del.addEventListener('click', (e) => {
-                        e.stopPropagation();
-                        if (!confirm('Delete this video?')) return;
-                        fetch(`/api/videos/${v.id}`, { method: 'DELETE' }).then(r => {
-                            if (r.ok) {
-                                videos.splice(i, 1);
-                                if (currentVideoIndex === i) {
-                                    currentVideoIndex = -1;
-                                    videoPlayer.removeAttribute('src');
-                                    videoPlayer.load();
-                                    bookmarkList.innerHTML = '';
-                                    markerContainer.innerHTML = '';
-                                    codeContainer.innerHTML = '';
-                                }
-                                renderVideoList();
+                    wrap.appendChild(header);
+                    container.appendChild(wrap);
+
+                    if (!cat.collapsed) {
+                        const inner = document.createElement('div');
+                        inner.style.marginLeft = '15px';
+                        build(cat.id, inner);
+                        wrap.appendChild(inner);
+                    }
+                });
+
+                vids.forEach(v => {
+                    const div = document.createElement('div');
+                    div.className = 'video-item';
+                    if (isAdmin) div.draggable = true;
+                    div.addEventListener('dragstart', e => { e.dataTransfer.setData('video', v.id); });
+                    const span = document.createElement('span');
+                    span.textContent = v.title;
+                    span.className = 'title-truncate';
+                    div.appendChild(span);
+                    if (isAdmin) {
+                        const edit = document.createElement('button');
+                        edit.textContent = '✎';
+                        edit.style.marginLeft = '5px';
+                        edit.addEventListener('click', (e) => {
+                            e.stopPropagation();
+                            const title = prompt('New title', v.title);
+                            if (title && title !== v.title) {
+                                fetch(`/api/videos/${v.id}`, {
+                                    method: 'PUT',
+                                    headers: { 'Content-Type': 'application/json' },
+                                    body: JSON.stringify({ title })
+                                }).then(r => { if (r.ok) { v.title = title; renderVideoList(); } });
                             }
                         });
-                    });
-                    div.appendChild(del);
+                        div.appendChild(edit);
+
+                        const del = document.createElement('button');
+                        del.textContent = '🗑';
+                        del.style.marginLeft = '5px';
+                        del.addEventListener('click', (e) => {
+                            e.stopPropagation();
+                            if (!confirm('Delete this video?')) return;
+                            fetch(`/api/videos/${v.id}`, { method: 'DELETE' }).then(r => {
+                                if (r.ok) {
+                                    const idx = videos.findIndex(x => x.id === v.id);
+                                    videos.splice(idx, 1);
+                                    if (currentVideoIndex === idx) {
+                                        currentVideoIndex = -1;
+                                        videoPlayer.removeAttribute('src');
+                                        videoPlayer.load();
+                                        bookmarkList.innerHTML = '';
+                                        markerContainer.innerHTML = '';
+                                        codeContainer.innerHTML = '';
+                                    }
+                                    renderVideoList();
+                                }
+                            });
+                        });
+                        div.appendChild(del);
+                    }
+                    div.addEventListener('click', () => loadVideo(videos.findIndex(x => x.id === v.id)));
+                    container.appendChild(div);
+                });
+            }
+
+            build(null, videoListDiv);
+            videoListDiv.ondragover = e => e.preventDefault();
+            videoListDiv.ondrop = e => {
+                const vid = e.dataTransfer.getData('video');
+                if (vid) {
+                    const vobj = videos.find(x => x.id == vid);
+                    if (!vobj) return;
+                    fetch(`/api/videos/${vid}`, {
+                        method: 'PUT',
+                        headers: { 'Content-Type': 'application/json' },
+                        body: JSON.stringify({ category_id: null })
+                    }).then(r => { if (r.ok) { vobj.category_id = null; renderVideoList(); } });
                 }
-                div.addEventListener('click', () => loadVideo(i));
-                videoListDiv.appendChild(div);
-            });
+            };
         }
 
         function renderBookmarkList() {
@@ -464,6 +579,20 @@
             if (!isAdmin) return;
             videoFileInput.value = '';
             videoFileInput.click();
+        });
+
+        addCategoryBtn.addEventListener('click', () => {
+            if (!isAdmin) return;
+            const name = prompt('Category name');
+            if (!name) return;
+            fetch('/api/categories', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ name })
+            }).then(r => r.json()).then(c => {
+                categories.push({ ...c, collapsed: false });
+                renderVideoList();
+            });
         });
 
         videoFileInput.addEventListener('change', (e) => {


### PR DESCRIPTION
## Summary
- add categories table and endpoints to group videos
- allow updating video category via PUT endpoint
- implement category creation UI and drag-drop to assign videos
- show categories in sidebar with collapsible subcategories

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686f962fe78c8323a5b43276adaef0bf